### PR TITLE
bump: geo-agent to @v3.1.0

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,8 +39,8 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/languages/sql.min.js"></script>
 
     <!-- Core styles from CDN -->
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/boettiger-lab/geo-agent@v3.0.2/app/style.css">
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/boettiger-lab/geo-agent@v3.0.2/app/chat.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/boettiger-lab/geo-agent@v3.1.0/app/style.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/boettiger-lab/geo-agent@v3.1.0/app/chat.css">
 </head>
 
 <body>
@@ -68,7 +68,7 @@
     </div>
 
     <!-- Boot from CDN -->
-    <script type="module" src="https://cdn.jsdelivr.net/gh/boettiger-lab/geo-agent@v3.0.2/app/main.js"></script>
+    <script type="module" src="https://cdn.jsdelivr.net/gh/boettiger-lab/geo-agent@v3.1.0/app/main.js"></script>
 </body>
 
 </html>


### PR DESCRIPTION
## Summary

Bumps the geo-agent library pin in `index.html` from the previous value to `@v3.1.0` (the latest geo-agent release, tagged 2026-04-14).

**Wave:** production. Per `geo-agent-ops/MIGRATIONS.md`, demo/internal apps are bumped first, then production apps after validation.

## Changes

- `index.html` — pin updated in 3 places (style.css, chat.css, main.js CDN URLs)


## Post-merge deploy

PR merge alone is **not** sufficient — k8s rollout is required to pick up the new pin.

```bash
kubectl rollout restart deployment/tpl-ca -n biodiversity
kubectl rollout status  deployment/tpl-ca -n biodiversity
```

## Validate after rollout

```bash
curl -s https://tpl-ca.nrp-nautilus.io/ | grep 'geo-agent@'
# expected: geo-agent@v3.1.0
```

## Tracking

Part of the v3.0.2 → v3.1.0 rollout tracked in `boettiger-lab/geo-agent-ops` (APPS.md pins + MIGRATIONS.md section to follow in an ops PR once all 5 app bumps are deployed).