### PR TITLE
Migrate to split almanac collections (sites + funding)

### DIFF
--- a/layers-input.json
+++ b/layers-input.json
@@ -347,12 +347,12 @@
             ]
         },
         {
-            "collection_id": "conservation-almanac-2024",
+            "collection_id": "conservation-almanac-2024-sites",
             "preload": true,
-            "collection_url": "https://s3-west.nrp-nautilus.io/public-tpl/stac-collection.json",
+            "collection_url": "https://s3-west.nrp-nautilus.io/public-tpl/conservation-almanac-2024-sites/stac-collection.json",
             "assets": [
                 {
-                    "id": "almanac-pmtiles",
+                    "id": "conservation-almanac-2024-sites-pmtiles",
                     "display_name": "TPL Conservation Almanac",
                     "group": "Conservation Areas",
                     "visible": true,
@@ -366,7 +366,7 @@
                         ],
                         "fill-opacity": 0.6
                     },
-                    "tooltip_fields": ["site", "owner", "owner_type", "manager", "access_type", "purchase_type", "acres", "amount", "program", "year", "county"]
+                    "tooltip_fields": ["site", "owner", "owner_type", "manager", "access_type", "purchase_type", "acres", "year", "county"]
                 }
             ]
         }

--- a/system-prompt.md
+++ b/system-prompt.md
@@ -12,54 +12,20 @@ When describing Conservation Almanac data, do not say "TPL-protected land" or im
 - "conservation investment in this district"
 - "funding from [program name]" when a specific program is known
 
-### Sponsors and multi-funder sites
+### Two collections joined by `tpl_id`
 
-**A single conservation site often has multiple sponsors.** The Almanac has one row per funding transaction: if a site received money from three programs, it appears as three rows sharing the same `tpl_id` and `fid`. The `program` column names the funding program, and `amount` is that sponsor's contribution.
+The Almanac is split into two collections. Use both together for any funding question.
 
-This means you can always look up exactly who funded a site and how much each contributed — this is one of the most useful things the agent can do. When a user asks about a specific site, a district's sponsors, or "who paid for this," query the flat parquet directly:
+- **`conservation-almanac-2024-sites`** — one row per protected site. Geometry, acres, ownership, access, year, location. **No funding info.** `SUM(acres)` is safe here.
+- **`conservation-almanac-2024-funding`** — one row per (site, program, sponsor) funding transaction. Amount, program, sponsor, sponsor_type. **No geometry, no hex variant.** `SUM(amount)` is safe — no geographic repetition.
 
-```sql
--- All sponsors for a named site
-SELECT site, county, year, program, amount, owner, owner_type, purchase_type
-FROM read_parquet('s3://public-tpl/conservation-almanac-2024.parquet')
-WHERE state = 'California'
-  AND site ILIKE '%Eel River%'
-ORDER BY amount DESC
-```
+Join on `tpl_id`. `get_dataset('conservation-almanac-2024-sites')` includes a worked Texas federal-funding join example — adapt it for California.
 
-```sql
--- Sponsor breakdown for all sites in a congressional district (via H3 join)
-WITH cd_hex AS (
-  SELECT DISTINCT h8, h0
-  FROM read_parquet('s3://public-census/census-2024/cd/hex/**')
-  WHERE STATEFP = '06' AND NAMELSAD = 'Congressional District 16'
-),
-tpl AS (
-  SELECT t.tpl_id, t.site, t.program, t.amount, t.acres, t.year
-  FROM read_parquet('s3://public-tpl/conservation-almanac-2024/hex/h0=*/data_0.parquet') t
-  JOIN cd_hex d ON t.h8 = d.h8 AND t.h0 = d.h0
-  WHERE t.state = 'California'
-)
-SELECT program,
-  COUNT(DISTINCT tpl_id) as n_sites,
-  ROUND(SUM(amount)/1e6, 1) as total_funding_M
-FROM tpl
-WHERE program IS NOT NULL AND program NOT IN ('n/a', '')
-GROUP BY program
-ORDER BY total_funding_M DESC
-```
+**Coded-value gotcha across the two collections.** `owner_type` on sites uses `PVT` and `TRIB`; `sponsor_type` on funding uses `PRIV` and `TRB`. Verify coded values from `get_dataset` before filtering.
 
-Key reminders:
-- **Funding:** `SUM(amount)` across all rows correctly totals funding — each row's `amount` is one sponsor's contribution
-- **Acres:** `SUM(acres)` double-counts because acres is repeated on every funding row for the same site. Always deduplicate with a CTE first:
-  ```sql
-  WITH site_acres AS (
-    SELECT tpl_id, MAX(acres) AS acres FROM ... GROUP BY tpl_id
-  )
-  SELECT SUM(acres) AS total_acres FROM site_acres
-  ```
-  **Never write `SUM(MAX(acres))`** — nested aggregate functions are not valid SQL and will error.
-- A site with `amount = 0` or null may still be significant — it may be a donation or a transaction where only acreage was recorded
+A legacy flat `conservation-almanac-2024` collection still exists for backwards compatibility. Prefer the split collections — on the flat collection `SUM(acres)` double-counts and you must dedupe by `tpl_id` first. Do not use the flat collection unless a user explicitly asks for a single-table view.
+
+**Ask before assuming on ambiguous queries.** "Most TPL projects" could mean distinct sites (sites collection), funding transactions (funding collection), total acres, or total dollars — briefly ask which. "Largest project" could mean by acres, funding, or number of funders. Keep the clarifying question to one sentence.
 
 ## About the LandMark Indigenous Lands Layer
 
@@ -69,146 +35,16 @@ The LandMark layer shows **formally recognized and documented Indigenous territo
 
 - **Coverage is incomplete by definition.** California has ~109 federally recognized tribes, but many have no federal land base and do not appear. There are also approximately 70 non-federally-recognized tribes in CA with no representation in this dataset.
 - **Boundaries reflect legal recognition, not cultural or ancestral territory.** The absence of a boundary does not mean the absence of tribal presence, cultural connection, or land claims.
-- **`ethncty_1` is blank for all CA records** — use the `name` field for identifying territories in queries and tooltips.
 - When a user asks about tribal engagement or indigenous lands, acknowledge these gaps rather than implying the map is a complete picture of tribal presence in California.
 
-You have access to two kinds of tools:
+## California scope
 
-1. **Map tools** (local) – control what's visible on the interactive map: show/hide layers, filter features, set styles.
-2. **SQL query tool** (remote) – run read-only DuckDB SQL against H3-indexed parquet datasets hosted on S3.
-
-## When to use which tool
-
-| User intent | Tool |
-|---|---|
-| "show", "display", "visualize", "hide" a layer | Map tools |
-| Filter to a subset on the map | `set_filter` |
-| Color / style the map layer | `set_style` |
-| "how many", "total", "calculate", "summarize" | SQL `query` |
-| Join two datasets, spatial analysis, ranking | SQL `query` |
-| "top 10 counties by …" | SQL `query` + then map tools |
-
-**Prefer visual first.** If the user says "show me the carbon data", use `show_layer`. Only query SQL if they ask for numbers.
-
-## SQL Query Guidelines
-
-The DuckDB instance is pre-configured with:
-- `THREADS = 100`
-- Extensions: `httpfs`, `h3`, `spatial`
-- Internal S3 endpoint for fast access
-
-**Always filter to California.** Unless the user explicitly asks for national or multi-state data, every query must include a California filter. The correct filter depends on the dataset:
-- TPL Conservation Almanac: `WHERE state = 'California'` or `WHERE state_id = 'CA'`
+**Always filter to California** unless the user explicitly asks for national or multi-state data. The correct filter depends on the dataset:
+- TPL Conservation Almanac sites: `WHERE state = 'California'` or `WHERE state_id = 'CA'`. The funding collection has no geometry or state column — filter via a join to sites on `tpl_id`.
 - Census legislative/congressional districts: `WHERE STATEFP = '06'`
 - CPAD: data is already California-only, no filter needed
 
 Never return intermediate results for other states as a stepping stone to California results — apply the filter from the start.
-
-**Ask before assuming on ambiguous queries.** When a user asks something that could be interpreted multiple ways — especially involving counts or aggregations over the TPL data — briefly explain the ambiguity and ask which they mean before running the query. For example:
-
-- "Most TPL projects" is ambiguous: the Conservation Almanac has **one row per funding transaction**, not one row per site. A single conservation site (`tpl_id`) shares the same geometry (`fid`) across multiple rows — one per funder. Ask the user whether they want:
-  - **Distinct conservation sites** (`COUNT(DISTINCT tpl_id)`) — counts each physical area once regardless of how many funders
-  - **Funding transactions** (`COUNT(*)`) — counts each grant/program separately
-  - **Total acres protected**: use a CTE to get `MAX(acres)` per `tpl_id` first, then `SUM` — acres is repeated on every funding row for the same site, so summing directly double-counts
-  - **Total dollars**: `SUM(amount)` across all rows — each row's `amount` is the funding from one sponsor, so summing all rows gives the correct total
-
-- "Largest project" is ambiguous: largest by acres, by total funding, or by number of funders?
-
-Keep the clarifying question short — one sentence is enough. Once the user answers, proceed directly.
-
-When writing SQL:
-- Use `read_parquet('s3://…')` with S3 paths from the dataset catalog
-- For partitioned datasets, use the `/**` wildcard path
-- H3 columns are typically `h3_index` or `h8`/`h10` at various resolutions
-- Always use `LIMIT` to keep results manageable
-
-### Example: Protected acreage by county
-
-```sql
-SELECT COUNTY, SUM(ACRES) AS total_acres, COUNT(*) AS num_holdings
-FROM read_parquet('s3://public-cpad/cpad-2025b-holdings.parquet')
-GROUP BY COUNTY
-ORDER BY total_acres DESC
-LIMIT 15
-```
-
-### Example: Carbon in protected areas (H3 join)
-
-```sql
-WITH cpad_hex AS (
-  SELECT h0, h8, UNIT_NAME, AGNCY_NAME
-  FROM read_parquet('s3://public-cpad/cpad-2025b-holdings/hex/**')
-),
-carbon AS (
-  SELECT h0, h8, carbon
-  FROM read_parquet('s3://public-carbon/irrecoverable-carbon-2024/hex/**')
-)
-SELECT
-  c.UNIT_NAME,
-  c.AGNCY_NAME,
-  SUM(ca.carbon) AS total_irrecoverable_carbon_MgC
-FROM cpad_hex c
-JOIN carbon ca ON c.h8 = ca.h8 AND c.h0 = ca.h0
-GROUP BY c.UNIT_NAME, c.AGNCY_NAME
-ORDER BY total_irrecoverable_carbon_MgC DESC
-LIMIT 10
-```
-
-### Example: Carbon by congressional district (H3 join)
-
-The hex parquet files include pre-computed H3 columns at multiple resolutions (`h8`, `h9`, `h10`). Join directly on `d.h8 = ca.h8` — no need to call `h3_cell_to_parent`. `STATEFP` is a zero-padded string (e.g., `'06'` for California).
-
-```sql
-WITH cd_hex AS (
-  SELECT h0, h8, NAMELSAD, GEOID
-  FROM read_parquet('s3://public-census/census-2024/cd/hex/**')
-  WHERE STATEFP = '06'
-),
-carbon AS (
-  SELECT h0, h8, carbon
-  FROM read_parquet('s3://public-carbon/irrecoverable-carbon-2024/hex/**')
-)
-SELECT
-  d.NAMELSAD,
-  d.GEOID,
-  SUM(ca.carbon) AS total_irrecoverable_carbon_MgC
-FROM cd_hex d
-JOIN carbon ca ON d.h8 = ca.h8 AND d.h0 = ca.h0
-GROUP BY d.NAMELSAD, d.GEOID
-ORDER BY total_irrecoverable_carbon_MgC DESC
-LIMIT 15
-```
-
-### Example: Vulnerable carbon by congressional district
-
-Vulnerable carbon uses the same column name (`carbon`) and the same join pattern. The three carbon types and their S3 paths (all with `hex/**`):
-
-| Type | S3 path |
-|---|---|
-| Irrecoverable | `s3://public-carbon/irrecoverable-carbon-2024/hex/**` |
-| Vulnerable | `s3://public-carbon/vulnerable-carbon-2024/hex/**` |
-| Manageable | `s3://public-carbon/manageable-carbon-2024/hex/**` |
-
-```sql
-WITH cd_hex AS (
-  SELECT h0, h8, NAMELSAD, GEOID
-  FROM read_parquet('s3://public-census/census-2024/cd/hex/**')
-  WHERE STATEFP = '06'
-),
-carbon AS (
-  SELECT h0, h8, carbon
-  FROM read_parquet('s3://public-carbon/vulnerable-carbon-2024/hex/**')
-)
-SELECT
-  d.NAMELSAD,
-  d.GEOID,
-  SUM(ca.carbon) AS total_vulnerable_carbon_MgC
-FROM cd_hex d
-JOIN carbon ca ON d.h8 = ca.h8 AND d.h0 = ca.h0
-GROUP BY d.NAMELSAD, d.GEOID
-ORDER BY total_vulnerable_carbon_MgC DESC
-LIMIT 15
-```
 
 ## Available datasets
 


### PR DESCRIPTION
Closes #10. Tracks boettiger-lab/data-workflows#126.

## Changes

### `layers-input.json`
Point the almanac map layer at the new `conservation-almanac-2024-sites` collection:
- `collection_id`: `conservation-almanac-2024` → `conservation-almanac-2024-sites`
- `collection_url`: flat bucket URL → `.../conservation-almanac-2024-sites/stac-collection.json`
- Asset `id`: `almanac-pmtiles` → `conservation-almanac-2024-sites-pmtiles`
- PMTiles source-layer is now `conservation-almanac-2024-sites` (declared by the new collection's `vector:layers`)
- Drop `amount` and `program` from `tooltip_fields` — those columns live only on the separate funding collection (tabular-only, no PMTiles)

### `system-prompt.md`
Includes the in-progress trim that was already staged locally (remove SQL examples, tool-use tables, and carbon/CPAD/congressional-district query templates — all now covered by `list_datasets` / `get_dataset`). On top of that, the Almanac aggregation guidance is rewritten for the two-collection model:
- Sites → `SUM(acres)` is safe, no funding columns
- Funding → `SUM(amount)` is safe, no geometry
- Join by `tpl_id`
- Cross-collection coded-value gotcha: `owner_type` uses `PVT/TRIB`; `sponsor_type` uses `PRIV/TRB`
- Legacy flat collection still exists; flagged as not-preferred

## Test plan

- [ ] Almanac map layer renders (pmtiles URL resolves, source-layer matches).
- [ ] Tooltip shows site attributes (no broken `amount`/`program` fields).
- [ ] California federal-funding question uses `conservation-almanac-2024-funding` with a `tpl_id` join to sites, no `MIN(h10) per tpl_id` dedup dance.
- [ ] No regression on acreage-by-county or site-count queries.