### PR TITLE
Add NWI Wetlands PMTiles layer

### DIFF
--- a/layers-input.json
+++ b/layers-input.json
@@ -26,7 +26,40 @@
     "collections": [
         {
             "collection_id": "wetlands-nwi",
-            "collection_url": "https://s3-west.nrp-nautilus.io/public-wetlands/nwi/stac-collection.json"
+            "collection_url": "https://s3-west.nrp-nautilus.io/public-wetlands/nwi/stac-collection.json",
+            "assets": [
+                {
+                    "id": "nwi-pmtiles",
+                    "display_name": "NWI Wetlands",
+                    "group": "Wetlands",
+                    "visible": false,
+                    "default_style": {
+                        "fill-color": [
+                            "match", ["get", "WETLAND_TYPE"],
+                            "Freshwater Emergent Wetland",        "#7CCD7C",
+                            "Freshwater Forested/Shrub Wetland",  "#008000",
+                            "Freshwater Pond",                    "#2980B9",
+                            "Lake",                               "#1F77B4",
+                            "Lakes",                              "#1F77B4",
+                            "Riverine",                           "#0099CC",
+                            "Estuarine and Marine Wetland",       "#FF7F00",
+                            "Estuarine and Marine Deepwater",     "#0F0F73",
+                            "#9E9E9E"
+                        ],
+                        "fill-opacity": 0.6
+                    },
+                    "outline_style": {
+                        "line-color": "#333333",
+                        "line-width": 0.3,
+                        "line-opacity": 0.5
+                    },
+                    "tooltip_fields": [
+                        "WETLAND_TYPE",
+                        "ATTRIBUTE",
+                        "state_code"
+                    ]
+                }
+            ]
         },
         {
             "collection_id": "irrecoverable-carbon",


### PR DESCRIPTION
Adds the new NWI Wetlands layer (just published at H3 res 10 with PMTiles vector tiles in boettiger-lab/data-workflows#156) to the tpl-ca app.

- **Tiles**: \`s3://public-wetlands/nwi-v2.pmtiles\` (source-layer \`nwi-v2\`, 13 GB, max zoom 14)
- **Group**: Wetlands
- **Default off** (heavy tile)
- **Styled by \`WETLAND_TYPE\`** using the standard USFWS palette: blues for open water (Lake, Riverine, Freshwater Pond) and Estuarine Deepwater; greens for Freshwater Emergent / Forested-Shrub; orange for Estuarine and Marine Wetland; gray for "Other"
- **Tooltip**: \`WETLAND_TYPE\`, \`ATTRIBUTE\` (Cowardin code), \`state_code\`
- Thin 0.3 px outline so individual features remain distinguishable at high zoom without dominating the overlay

Deploy after merge by rolling the \`tpl-ca\` deployment (the git-clone init container pulls main at pod startup).