### PR TITLE
Add 9 catalog-ready layers, wire funding table, pin geo-agent to main HEAD

### DIFF
--- a/docs.html
+++ b/docs.html
@@ -261,6 +261,11 @@ p.lede { font-size: 1.05rem; color: var(--ink-soft); }
             <div class="source">LandMark — global platform for indigenous and community lands, coordinated by the World Resources Institute and partners. Coverage reflects formal legal recognition only.</div>
             <div class="links"><a href="https://radiantearth.github.io/stac-browser/#/external/s3-west.nrp-nautilus.io/public-indigenous/landmark/iplc-poly-stac.json" target="_blank" rel="noopener">STAC</a><a href="https://www.landmarkmap.org" target="_blank" rel="noopener">Source</a></div>
         </div>
+        <div class="layer">
+            <div class="name">PAD-US 4.1 (Fee &amp; Combined)</div>
+            <div class="source">US Geological Survey Gap Analysis Project — Protected Areas Database of the United States. Fee layer covers fee-owned protected areas; Combined layer adds easements, marine areas, and proclamation boundaries.</div>
+            <div class="links"><a href="https://radiantearth.github.io/stac-browser/#/external/s3-west.nrp-nautilus.io/public-padus/padus-4-1/fee/stac-collection.json" target="_blank" rel="noopener">STAC: Fee</a><a href="https://radiantearth.github.io/stac-browser/#/external/s3-west.nrp-nautilus.io/public-padus/padus-4-1/combined/stac-collection.json" target="_blank" rel="noopener">STAC: Combined</a><a href="https://www.usgs.gov/programs/gap-analysis-project/science/protected-areas" target="_blank" rel="noopener">Source</a></div>
+        </div>
     </div>
 
     <div class="layer-group">
@@ -318,6 +323,34 @@ p.lede { font-size: 1.05rem; color: var(--ink-soft); }
             <div class="source">NatureServe Map of Biodiversity Importance — modeled species richness across all imperiled taxa in the United States.</div>
             <div class="links"><a href="https://radiantearth.github.io/stac-browser/#/external/s3-west.nrp-nautilus.io/public-mobi/mobi-species-richness-all/stac-collection.json" target="_blank" rel="noopener">STAC</a><a href="https://www.natureserve.org/conservation-tools/data-maps-tools/map-biodiversity-importance" target="_blank" rel="noopener">Source</a></div>
         </div>
+        <div class="layer">
+            <div class="name">IUCN Species Richness (2025)</div>
+            <div class="source">International Union for Conservation of Nature — Red List range maps rasterised to species-count grids for all terrestrial vertebrate taxa, with per-taxon breakdowns for mammals and birds.</div>
+            <div class="links"><a href="https://radiantearth.github.io/stac-browser/#/external/s3-west.nrp-nautilus.io/public-iucn/stac-collection.json" target="_blank" rel="noopener">STAC</a><a href="https://www.iucnredlist.org" target="_blank" rel="noopener">Source</a></div>
+        </div>
+        <div class="layer">
+            <div class="name">NCP Biodiversity Importance</div>
+            <div class="source">Nature's Contributions to People — composite biodiversity-importance indicators; the "× Natural Habitat" variant masks the index to natural-habitat cover.</div>
+            <div class="links"><a href="https://radiantearth.github.io/stac-browser/#/external/s3-west.nrp-nautilus.io/public-ncp/stac-collection.json" target="_blank" rel="noopener">STAC</a></div>
+        </div>
+    </div>
+
+    <div class="layer-group">
+        <h3>Demographics</h3>
+        <div class="layer">
+            <div class="name">Population Density (GHS-POP 2020)</div>
+            <div class="source">Global Human Settlement Layer (European Commission JRC) — 2020 population count at ~90m resolution, R2023A release.</div>
+            <div class="links"><a href="https://radiantearth.github.io/stac-browser/#/external/s3-west.nrp-nautilus.io/public-high-seas/ghs-pop-2020/stac-collection.json" target="_blank" rel="noopener">STAC</a><a href="https://human-settlement.emergency.copernicus.eu/ghs_pop.php" target="_blank" rel="noopener">Source</a></div>
+        </div>
+    </div>
+
+    <div class="layer-group">
+        <h3>Land Cover</h3>
+        <div class="layer">
+            <div class="name">Copernicus Global Land Cover (CGLS-LC100 2019)</div>
+            <div class="source">Copernicus Global Land Service v3.0.1 — 100m global land-cover classification (23 classes, FAO LCCS scheme).</div>
+            <div class="links"><a href="https://radiantearth.github.io/stac-browser/#/external/s3-west.nrp-nautilus.io/public-land-cover/cgls-lc100-2019/stac-collection.json" target="_blank" rel="noopener">STAC</a><a href="https://land.copernicus.eu/global/products/lc" target="_blank" rel="noopener">Source</a></div>
+        </div>
     </div>
 
     <div class="layer-group">
@@ -336,6 +369,11 @@ p.lede { font-size: 1.05rem; color: var(--ink-soft); }
             <div class="source">CAL FIRE Fire and Resource Assessment Program (FRAP) — official California fire history (perimeters and treated-fuels), 2024 release.</div>
             <div class="links"><a href="https://radiantearth.github.io/stac-browser/#/external/s3-west.nrp-nautilus.io/public-fire/calfire-2024/firep/stac-collection.json" target="_blank" rel="noopener">STAC: Perimeters</a><a href="https://radiantearth.github.io/stac-browser/#/external/s3-west.nrp-nautilus.io/public-fire/calfire-2024/rxburn/stac-collection.json" target="_blank" rel="noopener">STAC: RxBurns</a><a href="https://frap.fire.ca.gov" target="_blank" rel="noopener">Source</a></div>
         </div>
+        <div class="layer">
+            <div class="name">USGS Wildland Fires (1878–2020)</div>
+            <div class="source">USGS Wildland Fire Combined Dataset 2021 — a national, deduplicated synthesis of wildfire perimeters from federal, state, and tribal sources extending back to the late 1800s.</div>
+            <div class="links"><a href="https://radiantearth.github.io/stac-browser/#/external/s3-west.nrp-nautilus.io/public-fire/usgs-fires-2021/combined/stac-collection.json" target="_blank" rel="noopener">STAC</a><a href="https://www.sciencebase.gov/catalog/item/61aa537dd34eb622f699df81" target="_blank" rel="noopener">Source</a></div>
+        </div>
     </div>
 
     <div class="layer-group">
@@ -349,6 +387,11 @@ p.lede { font-size: 1.05rem; color: var(--ink-soft); }
             <div class="name">CalEnviroScreen 5.0</div>
             <div class="source">California Environmental Protection Agency, Office of Environmental Health Hazard Assessment — pollution and population-vulnerability screening for California census tracts.</div>
             <div class="links"><a href="https://radiantearth.github.io/stac-browser/#/external/s3-west.nrp-nautilus.io/public-calenviroscreen/stac-collection.json" target="_blank" rel="noopener">STAC</a><a href="https://oehha.ca.gov/calenviroscreen" target="_blank" rel="noopener">Source</a></div>
+        </div>
+        <div class="layer">
+            <div class="name">HOLC Redlining (Mapping Inequality)</div>
+            <div class="source">Mapping Inequality (Robert K. Nelson et al., University of Richmond Digital Scholarship Lab) — Home Owners' Loan Corporation neighborhood security grades A–D from the late 1930s, the historical basis of redlining.</div>
+            <div class="links"><a href="https://radiantearth.github.io/stac-browser/#/external/s3-west.nrp-nautilus.io/public-mappinginequality/stac-collection.json" target="_blank" rel="noopener">STAC</a><a href="https://dsl.richmond.edu/panorama/redlining/" target="_blank" rel="noopener">Source</a></div>
         </div>
     </div>
 

--- a/index.html
+++ b/index.html
@@ -39,9 +39,9 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/languages/sql.min.js"></script>
 
     <!-- Core styles from CDN -->
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/boettiger-lab/geo-agent@v3.7.0/app/style.css">
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/boettiger-lab/geo-agent@v3.7.0/app/chat.css">
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/boettiger-lab/geo-agent@v3.7.0/app/sidebar.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/boettiger-lab/geo-agent@0394b692709651d9bbc30ac5ebf315383431a3b8/app/style.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/boettiger-lab/geo-agent@0394b692709651d9bbc30ac5ebf315383431a3b8/app/chat.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/boettiger-lab/geo-agent@0394b692709651d9bbc30ac5ebf315383431a3b8/app/sidebar.css">
 </head>
 
 <body>
@@ -54,7 +54,7 @@
     <!-- Chat scaffold is built dynamically by the sidebar layout manager (v3.2.0+). -->
 
     <!-- Boot from CDN -->
-    <script type="module" src="https://cdn.jsdelivr.net/gh/boettiger-lab/geo-agent@v3.7.0/app/main.js"></script>
+    <script type="module" src="https://cdn.jsdelivr.net/gh/boettiger-lab/geo-agent@0394b692709651d9bbc30ac5ebf315383431a3b8/app/main.js"></script>
 </body>
 
 </html>

--- a/layers-input.json
+++ b/layers-input.json
@@ -687,6 +687,206 @@
                     "tooltip_fields": ["site", "owner", "owner_type", "manager", "access_type", "purchase_type", "acres", "year", "county"]
                 }
             ]
+        },
+        {
+            "collection_id": "conservation-almanac-2024-funding",
+            "preload": true,
+            "collection_url": "https://s3-west.nrp-nautilus.io/public-tpl/conservation-almanac-2024-funding/stac-collection.json"
+        },
+        {
+            "collection_id": "usgs-fires-2021-combined",
+            "collection_url": "https://s3-west.nrp-nautilus.io/public-fire/usgs-fires-2021/combined/stac-collection.json",
+            "assets": [
+                {
+                    "id": "combined-pmtiles",
+                    "display_name": "USGS Wildland Fires (1878–2020)",
+                    "group": "Fire",
+                    "visible": false,
+                    "default_style": {
+                        "fill-color": ["interpolate", ["linear"], ["to-number", ["get", "Fire_Year"]],
+                            1900, "#FFF3E0",
+                            1980, "#FFB74D",
+                            2010, "#E64A19",
+                            2020, "#B71C1C"
+                        ],
+                        "fill-opacity": 0.45
+                    },
+                    "outline_style": {
+                        "line-color": "#8D2A12",
+                        "line-width": 0.3
+                    },
+                    "tooltip_fields": ["Listed_Fire_Names", "Fire_Year", "GIS_Acres", "Assigned_Fire_Type", "Listed_Fire_Cause_Class"]
+                }
+            ]
+        },
+        {
+            "collection_id": "ghs-pop-2020",
+            "collection_url": "https://s3-west.nrp-nautilus.io/public-high-seas/ghs-pop-2020/stac-collection.json",
+            "assets": [
+                {
+                    "id": "ghs-pop-2020-cog",
+                    "display_name": "Population Density (GHS-POP 2020)",
+                    "group": "Demographics",
+                    "visible": false,
+                    "colormap": "magma",
+                    "rescale": "0,200",
+                    "legend_label": "Persons per ~90m cell (0–200)"
+                }
+            ]
+        },
+        {
+            "collection_id": "iucn-richness-2025",
+            "collection_url": "https://s3-west.nrp-nautilus.io/public-iucn/stac-collection.json",
+            "assets": [
+                {
+                    "id": "combined-sr-cog",
+                    "display_name": "IUCN Species Richness (all taxa)",
+                    "group": "Biodiversity",
+                    "visible": false,
+                    "colormap": "ylgn",
+                    "rescale": "0,500",
+                    "legend_label": "Species count (0–500)"
+                },
+                {
+                    "id": "mammals-sr-cog",
+                    "display_name": "IUCN Species Richness — Mammals",
+                    "group": "Biodiversity",
+                    "visible": false,
+                    "colormap": "ylgn",
+                    "rescale": "0,150",
+                    "legend_label": "Mammal species (0–150)"
+                },
+                {
+                    "id": "birds-sr-cog",
+                    "display_name": "IUCN Species Richness — Birds",
+                    "group": "Biodiversity",
+                    "visible": false,
+                    "colormap": "ylgn",
+                    "rescale": "0,400",
+                    "legend_label": "Bird species (0–400)"
+                }
+            ]
+        },
+        {
+            "collection_id": "ncp-biodiversity",
+            "collection_url": "https://s3-west.nrp-nautilus.io/public-ncp/stac-collection.json",
+            "assets": [
+                {
+                    "id": "ncp-only-cog",
+                    "display_name": "NCP Biodiversity Importance",
+                    "group": "Biodiversity",
+                    "visible": false,
+                    "colormap": "viridis",
+                    "rescale": "0,1",
+                    "legend_label": "NCP index (0–1)"
+                },
+                {
+                    "id": "ncp-biod-nathab-cog",
+                    "display_name": "NCP Biodiversity × Natural Habitat",
+                    "group": "Biodiversity",
+                    "visible": false,
+                    "colormap": "viridis",
+                    "rescale": "0,1",
+                    "legend_label": "NCP × habitat (0–1)"
+                }
+            ]
+        },
+        {
+            "collection_id": "cgls-lc100-2019",
+            "collection_url": "https://s3-west.nrp-nautilus.io/public-land-cover/cgls-lc100-2019/stac-collection.json",
+            "assets": [
+                {
+                    "id": "cgls-lc100-2019-cog",
+                    "display_name": "Land Cover (Copernicus CGLS 2019)",
+                    "group": "Land Cover",
+                    "visible": false,
+                    "legend_type": "categorical",
+                    "legend_label": "CGLS land-cover class"
+                }
+            ]
+        },
+        {
+            "collection_id": "pad-us-4.1-fee",
+            "collection_url": "https://s3-west.nrp-nautilus.io/public-padus/padus-4-1/fee/stac-collection.json",
+            "assets": [
+                {
+                    "id": "fee-pmtiles",
+                    "display_name": "PAD-US Fee (national)",
+                    "group": "Conservation Areas",
+                    "visible": false,
+                    "default_style": {
+                        "fill-color": ["match", ["get", "GAP_Sts"],
+                            "1", "#1B5E20",
+                            "2", "#43A047",
+                            "3", "#A5D6A7",
+                            "4", "#E0E0E0",
+                            "#9E9E9E"
+                        ],
+                        "fill-opacity": 0.45
+                    },
+                    "outline_style": {
+                        "line-color": "#1B5E20",
+                        "line-width": 0.3
+                    },
+                    "tooltip_fields": ["Unit_Nm", "Mang_Name", "Mang_Type", "Own_Type", "GAP_Sts", "Pub_Access", "GIS_Acres", "State_Nm"]
+                }
+            ]
+        },
+        {
+            "collection_id": "pad-us-4.1-combined",
+            "collection_url": "https://s3-west.nrp-nautilus.io/public-padus/padus-4-1/combined/stac-collection.json",
+            "assets": [
+                {
+                    "id": "combined-pmtiles",
+                    "display_name": "PAD-US Combined (all protection types)",
+                    "group": "Conservation Areas",
+                    "visible": false,
+                    "default_style": {
+                        "fill-color": ["match", ["get", "Category"],
+                            "Fee",          "#2E7D32",
+                            "Easement",     "#6A1B9A",
+                            "Marine",       "#0277BD",
+                            "Proclamation", "#FF8F00",
+                            "Designation",  "#558B2F",
+                            "#9E9E9E"
+                        ],
+                        "fill-opacity": 0.4
+                    },
+                    "outline_style": {
+                        "line-color": "#424242",
+                        "line-width": 0.3
+                    },
+                    "tooltip_fields": ["Unit_Nm", "Category", "Des_Tp", "Mang_Name", "Own_Type", "GAP_Sts", "Pub_Access", "GIS_Acres", "State_Nm"]
+                }
+            ]
+        },
+        {
+            "collection_id": "mappinginequality",
+            "collection_url": "https://s3-west.nrp-nautilus.io/public-mappinginequality/stac-collection.json",
+            "assets": [
+                {
+                    "id": "mappinginequality-pmtiles",
+                    "display_name": "HOLC Redlining (Mapping Inequality)",
+                    "group": "Social Vulnerability",
+                    "visible": false,
+                    "default_filter": ["==", ["get", "state"], "CA"],
+                    "default_style": {
+                        "fill-color": ["match", ["get", "grade"],
+                            "A", "#1B5E20",
+                            "B", "#1565C0",
+                            "C", "#F9A825",
+                            "D", "#C62828",
+                            "#9E9E9E"
+                        ],
+                        "fill-opacity": 0.55
+                    },
+                    "outline_style": {
+                        "line-color": "#424242",
+                        "line-width": 0.3
+                    },
+                    "tooltip_fields": ["city", "state", "grade", "category", "label", "residential", "commercial", "industrial"]
+                }
+            ]
         }
     ]
 }


### PR DESCRIPTION
Lands wave-1 layers from the May 2026 feedback triage (#18) and closes #4 by exposing the funding sibling collection to the agent.

## What's added

Eleven new map layers + one tabular collection in `layers-input.json`:

| Group | Layer | Source collection |
|---|---|---|
| Fire | USGS Wildland Fires (1878–2020) | `usgs-fires-2021-combined` |
| Demographics (new) | Population Density (GHS-POP 2020) | `ghs-pop-2020` |
| Biodiversity | IUCN Species Richness (all / mammals / birds) | `iucn-richness-2025` |
| Biodiversity | NCP Biodiversity Importance / × Natural Habitat | `ncp-biodiversity` |
| Land Cover (new) | Copernicus CGLS-LC100 2019 | `cgls-lc100-2019` |
| Conservation Areas | PAD-US 4.1 Fee | `pad-us-4.1-fee` |
| Conservation Areas | PAD-US 4.1 Combined | `pad-us-4.1-combined` |
| Social Vulnerability | HOLC Redlining (Mapping Inequality) | `mappinginequality` |
| _(tabular only)_ | TPL Conservation Almanac Funding | `conservation-almanac-2024-funding` |

The tabular `conservation-almanac-2024-funding` collection has no map assets — it joins to `-sites` on `tpl_id` and carries the `program` / `amount` / `sponsor` / `sponsor_type` columns that #4 flagged as missing. Exposing it via `layers-input.json` puts the columns into the LLM's STAC context so LWCF / funding-by-program queries can be answered in 1–2 tool calls instead of looping.

`docs.html` updated with matching source entries for every new layer.

## What's deferred

Two layers from #18 wave-1 are intentionally not in this PR:

- **CA DAC / EDA 2023** (`ca-dac-eda-2023`) — STAC PMTiles assets have `vector:layers: null`
- **Census 2024 Tracts** (`census-2024-tract`) — same

Per `AGENTS.md`, when `vector:layers` is missing the framework falls back to the STAC asset key as the source-layer name, but the actual PMTiles internal layer is `tract` — so these would silently render nothing. Filing follow-up data-workflows issues to patch `vector:layers` on both collections; adding them here once that lands is a one-block edit.

## geo-agent pin

Pinned to main HEAD `0394b692709651d9bbc30ac5ebf315383431a3b8` rather than a tag. No v3.7.1 release exists yet, and main carries the sidebar CSS polish (boettiger-lab/geo-agent#223) merged today.

## Closes

- Closes #4 (root cause was upstream STAC patch — column `program`/`amount`/`sponsor`/`sponsor_type` now live on `-funding` sibling, wired in here).
- Closes #6 (American Rivers — already wired in `layers-input.json` since April).

## Test plan

- [ ] Open preview, confirm all 11 new layers appear in the menu under the right group
- [ ] Toggle each new PMTiles layer (USGS fires, PAD-US fee, PAD-US combined, redlining); confirm tiles render and tooltips populate
- [ ] Toggle each new COG raster (GHS-POP, IUCN ×3, NCP ×2, CGLS); confirm titiler tiles render with the legend
- [ ] Ask the agent: "How much has LWCF invested in Senate District 2?" — confirm it now finds `conservation-almanac-2024-funding` and answers in <5 tool calls (vs prior 6-10+)
- [ ] Confirm sidebar still works (geo-agent main HEAD pin)

Refs: #18, boettiger-lab/geo-agent#223