### PR TITLE
Add CA DAC tract and California Census tract layers

### DIFF
--- a/docs.html
+++ b/docs.html
@@ -393,6 +393,11 @@ p.lede { font-size: 1.05rem; color: var(--ink-soft); }
             <div class="source">Mapping Inequality (Robert K. Nelson et al., University of Richmond Digital Scholarship Lab) — Home Owners' Loan Corporation neighborhood security grades A–D from the late 1930s, the historical basis of redlining.</div>
             <div class="links"><a href="https://radiantearth.github.io/stac-browser/#/external/s3-west.nrp-nautilus.io/public-mappinginequality/stac-collection.json" target="_blank" rel="noopener">STAC</a><a href="https://dsl.richmond.edu/panorama/redlining/" target="_blank" rel="noopener">Source</a></div>
         </div>
+        <div class="layer">
+            <div class="name">CA Disadvantaged Communities (DAC 2023)</div>
+            <div class="source">California Department of Water Resources — official DAC designation (median household income &lt; 80% of statewide MHI, Water Code §79505.5(a)) at Census tract level. Used to determine eligibility for Proposition 1, Proposition 68, and SGMA water-funding programs.</div>
+            <div class="links"><a href="https://radiantearth.github.io/stac-browser/#/external/s3-west.nrp-nautilus.io/public-ca-dac/stac-collection.json" target="_blank" rel="noopener">STAC</a><a href="https://water.ca.gov/Programs/Integrated-Regional-Water-Management/Disadvantaged-Communities" target="_blank" rel="noopener">Source</a></div>
+        </div>
     </div>
 
     <div class="layer-group">
@@ -401,6 +406,11 @@ p.lede { font-size: 1.05rem; color: var(--ink-soft); }
             <div class="name">Congressional, Assembly &amp; Senate Districts</div>
             <div class="source">US Census Bureau TIGER/Line — 119th Congress districts (2024) and California State Legislative Districts (2025).</div>
             <div class="links"><a href="https://radiantearth.github.io/stac-browser/#/external/s3-west.nrp-nautilus.io/public-census/census-2024/cd/stac-collection.json" target="_blank" rel="noopener">STAC: CD</a><a href="https://radiantearth.github.io/stac-browser/#/external/s3-west.nrp-nautilus.io/public-census/census-2025/sldl/stac-collection.json" target="_blank" rel="noopener">STAC: Assembly</a><a href="https://radiantearth.github.io/stac-browser/#/external/s3-west.nrp-nautilus.io/public-census/census-2025/sldu/stac-collection.json" target="_blank" rel="noopener">STAC: Senate</a><a href="https://www.census.gov/geographies/mapping-files/time-series/geo/tiger-line-file.html" target="_blank" rel="noopener">Source</a></div>
+        </div>
+        <div class="layer">
+            <div class="name">California Census Tracts (2024)</div>
+            <div class="source">US Census Bureau TIGER/Line 2024 — California tract boundaries, the standard sub-county geography used by ACS, CalEnviroScreen, SVI, and the DWR DAC layers.</div>
+            <div class="links"><a href="https://radiantearth.github.io/stac-browser/#/external/s3-west.nrp-nautilus.io/public-census/census-2024/tract/stac-collection.json" target="_blank" rel="noopener">STAC</a><a href="https://www.census.gov/geographies/mapping-files/time-series/geo/tiger-line-file.html" target="_blank" rel="noopener">Source</a></div>
         </div>
     </div>
 

--- a/layers-input.json
+++ b/layers-input.json
@@ -887,6 +887,53 @@
                     "tooltip_fields": ["city", "state", "grade", "category", "label", "residential", "commercial", "industrial"]
                 }
             ]
+        },
+        {
+            "collection_id": "ca-dac-eda-2023",
+            "collection_url": "https://s3-west.nrp-nautilus.io/public-ca-dac/stac-collection.json",
+            "assets": [
+                {
+                    "id": "dac-tract-pmtiles",
+                    "display_name": "CA Disadvantaged Communities (DAC, tract)",
+                    "group": "Social Vulnerability",
+                    "visible": false,
+                    "default_style": {
+                        "fill-color": ["match", ["get", "DAC23"],
+                            "Y", "#C62828",
+                            "N", "#BDBDBD",
+                            "#EEEEEE"
+                        ],
+                        "fill-opacity": 0.55
+                    },
+                    "outline_style": {
+                        "line-color": "#555555",
+                        "line-width": 0.3
+                    },
+                    "tooltip_fields": ["GEOID20", "DAC23", "MHI23", "Pop23", "HH23", "Source"]
+                }
+            ]
+        },
+        {
+            "collection_id": "census-2024-tract",
+            "collection_url": "https://s3-west.nrp-nautilus.io/public-census/census-2024/tract/stac-collection.json",
+            "assets": [
+                {
+                    "id": "tract-pmtiles",
+                    "display_name": "California Census Tracts",
+                    "group": "Political Boundaries",
+                    "visible": false,
+                    "default_style": {
+                        "fill-color": "#37474F",
+                        "fill-opacity": 0.05
+                    },
+                    "outline_style": {
+                        "line-color": "#37474F",
+                        "line-width": 1.0
+                    },
+                    "default_filter": ["==", ["get", "STATEFP"], "06"],
+                    "tooltip_fields": ["NAMELSAD", "GEOID", "TRACTCE", "COUNTYFP"]
+                }
+            ]
         }
     ]
 }


### PR DESCRIPTION
Lands the two layers from #18 wave 1 that were deferred in #20, now that **boettiger-lab/data-workflows#163** has patched the missing \`vector:layers\` metadata.

## Added

| Group | Layer | Notes |
|---|---|---|
| Social Vulnerability | CA Disadvantaged Communities (DAC, tract) | DWR official designation (MHI < 80% of statewide), styled binary on \`DAC23\` (Y/N/Data Not Available). |
| Political Boundaries | California Census Tracts | TIGER 2024, filtered to \`STATEFP=06\`. Selectable like the existing county / CD / Assembly / Senate layers. |

## User asks this addresses

- Abernethy — "Climate Bond Disadvantaged Communities" (explicit dataset)
- Wu, Ojeda — "demographics" / "information about demographics and populations"
- Ojeda — "I want to be able to select locations by tract, city, and county" (the missing tract picker)

## Test plan

- [ ] Toggle "CA Disadvantaged Communities (DAC, tract)" — confirm red fill on DAC tracts, grey on non-DAC, tooltip shows \`GEOID20\` / \`DAC23\` / \`MHI23\`.
- [ ] Toggle "California Census Tracts" — confirm thin outlines render statewide and clicking a tract surfaces \`NAMELSAD\` / \`GEOID\`.
- [ ] Ask the agent: "Which CA Assembly districts have the most DAC tracts?" — confirm it can find and join \`ca-dac-eda-2023\` against the assembly boundary layer.

Refs: #18, #20, boettiger-lab/data-workflows#163