### PR TITLE
Add 'ask the assistant' callout to docs

### DIFF
--- a/docs.html
+++ b/docs.html
@@ -212,7 +212,10 @@ p.lede { font-size: 1.05rem; color: var(--ink-soft); }
 
 <section>
     <h2>Working with the Data Assistant</h2>
-    <p>The Data Assistant doesn't just answer questions — it can drive the map for you. Most of the things people reach for a settings menu to do can be asked in plain language:</p>
+    <div class="callout">
+        <strong>If you wish the app could do something — just ask the assistant.</strong> Things people often reach for a settings menu to do (adjust transparency, export a CSV, filter a layer, run a cross-dataset query) the assistant can already do in plain language. If it can't, it will say so and usually suggest the closest thing it can.
+    </div>
+    <p>A few of the actions people most often ask for:</p>
     <ul>
         <li><strong>Adjust layer styling and transparency:</strong> <em>"Make Wildfire Perimeters 50% transparent"</em>, <em>"Color CalEnviroScreen by pollution percentile"</em>, <em>"Shade WCB projects by funding amount."</em></li>
         <li><strong>Show, hide, or filter layers:</strong> <em>"Turn on Indigenous Territories and turn off Conservation Easements"</em>, <em>"Show only fires after 2015"</em>, <em>"Hide everything except Conservation Almanac sites in Senate District 2."</em></li>
@@ -226,7 +229,7 @@ p.lede { font-size: 1.05rem; color: var(--ink-soft); }
         <li>Use the header button to <strong>minimize</strong> the panel; a floating "show" button restores it.</li>
         <li>On phones and tablets, the panel auto-collapses to overlay mode so the full map stays visible.</li>
         <li>PMTiles layers don't use a fixed legend. <strong>Hover</strong> over any feature for a tooltip with that feature's live attributes — values, names, categories — direct from the source data.</li>
-        <li>Every tool call the assistant runs is logged in the per-turn timeline so you can see exactly what it queried, with what arguments, and what came back.</li>
+        <li>Every tool call the assistant runs is logged in the per-turn timeline — with timings — so you can see what it queried, with what arguments, what came back, and how long each step took.</li>
     </ul>
 </section>
 


### PR DESCRIPTION
Surfaces the meta-tip from the May 2026 user-feedback debrief: capabilities users wished for (CSV export, transparency, filters, cross-dataset queries) are already available — they just need to ask the assistant. Also adds a brief note that the per-turn timeline shows step timings, which is the closest analogue to a runtime estimate.

Refs: #18