### PR TITLE
Add EPA Community Water System Service Areas

### DIFF
--- a/docs.html
+++ b/docs.html
@@ -357,6 +357,15 @@ p.lede { font-size: 1.05rem; color: var(--ink-soft); }
     </div>
 
     <div class="layer-group">
+        <h3>Water Utilities</h3>
+        <div class="layer">
+            <div class="name">Community Water System Service Areas (EPA SAB v3)</div>
+            <div class="source">US EPA Office of Research and Development — service-area boundaries for 44,656 community drinking-water systems (CWS), covering ~99% of the US population served by community water systems. Approximately 60% are authoritative boundaries from state primacy agencies; the remainder are EPA-modeled (the <code>Model_Method</code> field records which). Each polygon carries a <code>PWSID</code> for joining to SDWIS.</div>
+            <div class="links"><a href="https://radiantearth.github.io/stac-browser/#/external/s3-west.nrp-nautilus.io/public-epa-water/epa-sab-v3/cws/stac-collection.json" target="_blank" rel="noopener">STAC</a><a href="https://www.epa.gov/ground-water-and-drinking-water/community-water-system-service-area-boundaries" target="_blank" rel="noopener">Source</a></div>
+        </div>
+    </div>
+
+    <div class="layer-group">
         <h3>Wetlands</h3>
         <div class="layer">
             <div class="name">Wetland Type (GLWD v2)</div>

--- a/layers-input.json
+++ b/layers-input.json
@@ -934,6 +934,35 @@
                     "tooltip_fields": ["NAMELSAD", "GEOID", "TRACTCE", "COUNTYFP"]
                 }
             ]
+        },
+        {
+            "collection_id": "epa-sab-v3-cws",
+            "collection_url": "https://s3-west.nrp-nautilus.io/public-epa-water/epa-sab-v3/cws/stac-collection.json",
+            "assets": [
+                {
+                    "id": "sab-cws-pmtiles",
+                    "display_name": "Community Water System Service Areas (EPA)",
+                    "group": "Water Utilities",
+                    "visible": false,
+                    "default_filter": ["==", ["get", "Primacy_Agency"], "CA"],
+                    "default_style": {
+                        "fill-color": ["match", ["get", "Pop_Cat_5"],
+                            "<=500",          "#E3F2FD",
+                            "501-3,300",      "#90CAF9",
+                            "3,301-10,000",   "#42A5F5",
+                            "10,001-100,000", "#1976D2",
+                            ">100,000",       "#0D47A1",
+                            "#9E9E9E"
+                        ],
+                        "fill-opacity": 0.5
+                    },
+                    "outline_style": {
+                        "line-color": "#0D47A1",
+                        "line-width": 0.4
+                    },
+                    "tooltip_fields": ["PWS_Name", "PWSID", "Primacy_Agency", "Pop_Cat_5", "Population_Served_Count", "Service_Area_Type", "Model_Method"]
+                }
+            ]
         }
     ]
 }


### PR DESCRIPTION
Mirrors the EPA SAB v3 layer recently added to the main TPL app. Polygon service-area boundaries for 44,656 community water systems (CWS), covering ~99% of the US population served by community drinking water. Each polygon carries a \`PWSID\` for SDWIS joins.

Styled by \`Pop_Cat_5\` (population-served bins) matching the main TPL app, plus a \`Primacy_Agency = CA\` filter for the California focus.

Adds a new "Water Utilities" group in both layers-input.json and docs.html.

## Test plan

- [ ] Toggle "Community Water System Service Areas (EPA)" — confirm CA-only utilities render, fill scales with population category, tooltip surfaces PWSID / PWS_Name / Primacy_Agency.
- [ ] Ask the agent: "Which water utility serves a given location" — confirm it can join PWSID across collections.