### PR TITLE
Pin geo-agent to c5e08c3 (sidebar splitter)

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,9 +39,9 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/languages/sql.min.js"></script>
 
     <!-- Core styles from CDN -->
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/boettiger-lab/geo-agent@0394b692709651d9bbc30ac5ebf315383431a3b8/app/style.css">
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/boettiger-lab/geo-agent@0394b692709651d9bbc30ac5ebf315383431a3b8/app/chat.css">
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/boettiger-lab/geo-agent@0394b692709651d9bbc30ac5ebf315383431a3b8/app/sidebar.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/boettiger-lab/geo-agent@c5e08c39161ebd39d5e092fa6c42bfd1a548617d/app/style.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/boettiger-lab/geo-agent@c5e08c39161ebd39d5e092fa6c42bfd1a548617d/app/chat.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/boettiger-lab/geo-agent@c5e08c39161ebd39d5e092fa6c42bfd1a548617d/app/sidebar.css">
 </head>
 
 <body>
@@ -54,7 +54,7 @@
     <!-- Chat scaffold is built dynamically by the sidebar layout manager (v3.2.0+). -->
 
     <!-- Boot from CDN -->
-    <script type="module" src="https://cdn.jsdelivr.net/gh/boettiger-lab/geo-agent@0394b692709651d9bbc30ac5ebf315383431a3b8/app/main.js"></script>
+    <script type="module" src="https://cdn.jsdelivr.net/gh/boettiger-lab/geo-agent@c5e08c39161ebd39d5e092fa6c42bfd1a548617d/app/main.js"></script>
 </body>
 
 </html>


### PR DESCRIPTION
Bumps the geo-agent CDN pin from `0394b69` to `c5e08c3` (latest main) across all four references in index.html (style.css, chat.css, sidebar.css, main.js).

This brings in the draggable sidebar splitter + chat-collapse toggle (geo-agent commit 58f5581), which landed after the previous pin. Matches the pin now running on the tpl app.

jsDelivr serving the commit was verified (HTTP 200).