### PR TITLE
Bump geo-agent to afcf82e + add chat_title heading

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,9 +39,9 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/languages/sql.min.js"></script>
 
     <!-- Core styles from CDN -->
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/boettiger-lab/geo-agent@c5e08c39161ebd39d5e092fa6c42bfd1a548617d/app/style.css">
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/boettiger-lab/geo-agent@c5e08c39161ebd39d5e092fa6c42bfd1a548617d/app/chat.css">
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/boettiger-lab/geo-agent@c5e08c39161ebd39d5e092fa6c42bfd1a548617d/app/sidebar.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/boettiger-lab/geo-agent@afcf82e9a720f9f7d1bb853e17675c6e2ed77389/app/style.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/boettiger-lab/geo-agent@afcf82e9a720f9f7d1bb853e17675c6e2ed77389/app/chat.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/boettiger-lab/geo-agent@afcf82e9a720f9f7d1bb853e17675c6e2ed77389/app/sidebar.css">
 </head>
 
 <body>
@@ -54,7 +54,7 @@
     <!-- Chat scaffold is built dynamically by the sidebar layout manager (v3.2.0+). -->
 
     <!-- Boot from CDN -->
-    <script type="module" src="https://cdn.jsdelivr.net/gh/boettiger-lab/geo-agent@c5e08c39161ebd39d5e092fa6c42bfd1a548617d/app/main.js"></script>
+    <script type="module" src="https://cdn.jsdelivr.net/gh/boettiger-lab/geo-agent@afcf82e9a720f9f7d1bb853e17675c6e2ed77389/app/main.js"></script>
 </body>
 
 </html>

--- a/layers-input.json
+++ b/layers-input.json
@@ -6,7 +6,8 @@
     "sidebar": {
         "enabled": true,
         "default_width": 460,
-        "title": "TPL CA Data Assistant"
+        "title": "TPL CA Data Assistant",
+        "chat_title": "Chat"
     },
     "links": {
         "github": "https://github.com/boettiger-lab/tpl-ca",


### PR DESCRIPTION
Updates the geo-agent CDN pin from `c5e08c3` to `afcf82e` (latest main), which includes the new `sidebar.chat_title` feature (geo-agent #231).

Also adds `"chat_title": "Chat"` to the sidebar block so a persistent "Chat" heading shows above the chat section (parallel to the layers "Overlays" label). Without this field the new code is inert.

jsDelivr serving the commit was verified (HTTP 200).