### PR TITLE
k8s: pin namespace (biodiversity) + drop retired SECRETS_EXPOSURE pointer

### DIFF
--- a/k8s/configmap.yaml
+++ b/k8s/configmap.yaml
@@ -4,11 +4,10 @@
 # below), which injects the Authorization header server-side via
 # `proxy_set_header`. The browser only sees a relative `/api/llm`
 # endpoint and never holds the key.
-#
-# See ../../geo-agent-ops/SECRETS_EXPOSURE.md for the migration plan.
 apiVersion: v1
 kind: ConfigMap
 metadata:
+  namespace: biodiversity
   name: tpl-ca-config
 data:
   config.template.json: |
@@ -73,6 +72,7 @@ data:
 apiVersion: v1
 kind: ConfigMap
 metadata:
+  namespace: biodiversity
   name: tpl-ca-nginx
 data:
   nginx.conf.template: |

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -1,6 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  namespace: biodiversity
   name: tpl-ca
   labels:
     app: tpl-ca

--- a/k8s/ingress.yaml
+++ b/k8s/ingress.yaml
@@ -1,6 +1,7 @@
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
+  namespace: biodiversity
   name: tpl-ca-ingress
   annotations:
     haproxy-ingress.github.io/cors-enable: "true"

--- a/k8s/service.yaml
+++ b/k8s/service.yaml
@@ -1,6 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
+  namespace: biodiversity
   name: tpl-ca
   labels:
     app: tpl-ca


### PR DESCRIPTION
Manifest hygiene tracked in geo-agent-ops.

- **Pin namespace** (biodiversity) in each manifest's `metadata:` so `kubectl apply -f k8s/` targets the right namespace without `-n` (kills the guess-the-namespace step on every rollout; APPS.md TODO).

- **Drop the dangling `SECRETS_EXPOSURE.md` pointer** from the configmap comment — that doc was retired in geo-agent-ops@6be2c1e after the proxy-key leak was closed and the key rotated (April 2026). The surrounding "NO SECRETS / key lives only in nginx" comment stays.

No behavioral change — apps already run in this namespace.