### PR TITLE
ops: bump geo-agent pin v3.15.0 → v3.16.0

### DIFF
--- a/index.html
+++ b/index.html
@@ -60,9 +60,9 @@
         crossorigin="anonymous"></script>
 
     <!-- Core styles from CDN -->
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/boettiger-lab/geo-agent@v3.15.0/app/style.css">
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/boettiger-lab/geo-agent@v3.15.0/app/chat.css">
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/boettiger-lab/geo-agent@v3.15.0/app/sidebar.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/boettiger-lab/geo-agent@v3.16.0/app/style.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/boettiger-lab/geo-agent@v3.16.0/app/chat.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/boettiger-lab/geo-agent@v3.16.0/app/sidebar.css">
 </head>
 
 <body>
@@ -75,7 +75,7 @@
     <!-- Chat scaffold is built dynamically by the sidebar layout manager (v3.2.0+). -->
 
     <!-- Boot from CDN -->
-    <script type="module" src="https://cdn.jsdelivr.net/gh/boettiger-lab/geo-agent@v3.15.0/app/main.js"></script>
+    <script type="module" src="https://cdn.jsdelivr.net/gh/boettiger-lab/geo-agent@v3.16.0/app/main.js"></script>
 </body>
 
 </html>


### PR DESCRIPTION
Pure CDN pin bump to latest release v3.16.0. index.html is byte-unchanged between these tags upstream; only the @vX.Y.Z pin string moves. Part of fleet-wide rollout tracked in geo-agent-ops.