### PR TITLE
default model: minimax-m2 → qwen3

### DIFF
--- a/k8s/configmap.yaml
+++ b/k8s/configmap.yaml
@@ -13,7 +13,7 @@ data:
   config.template.json: |
     {
         "mcp_server_url": "${MCP_SERVER_URL}",
-        "llm_model": "minimax-m2",
+        "llm_model": "qwen3",
         "llm_models": [
             {
                 "value": "glm-5",


### PR DESCRIPTION
Migrate the boot default from `minimax-m2` to `qwen3` (the model ca-30x30/wyoming already default to). Picker list unchanged; `minimax-m2` stays selectable. Part of fleet-wide default migration — geo-agent-ops#30.