### PR TITLE
DSE-nimbus (qwen) model option; retire dead nemotron id

### DIFF
--- a/k8s/configmap.yaml
+++ b/k8s/configmap.yaml
@@ -22,8 +22,8 @@ data:
                 "api_key": "unused"
             },
             {
-                "value": "nemotron",
-                "label": "DSE Nemotron",
+                "value": "qwen",
+                "label": "DSE-nimbus",
                 "endpoint": "/api/llm",
                 "api_key": "unused"
             },


### PR DESCRIPTION
The Nimbus/DSE host now serves `nvidia/Qwen3.6-35B-A3B-NVFP4` under proxy model id `qwen` (was `nemotron`, renamed in [open-llm-proxy#62](https://github.com/boettiger-lab/open-llm-proxy/pull/62), live in the proxy since 2026-07-05). The old `nemotron` picker value no longer routes.

This relabels the picker entry to **DSE-nimbus** (the host machine) pointing at model `qwen`. Fleet-wide change tracked in geo-agent-ops.