### PR TITLE
Make DSE-nimbus (qwen) the default model

### DIFF
--- a/k8s/configmap.yaml
+++ b/k8s/configmap.yaml
@@ -13,7 +13,7 @@ data:
   config.template.json: |
     {
         "mcp_server_url": "${MCP_SERVER_URL}",
-        "llm_model": "qwen3",
+        "llm_model": "qwen",
         "llm_models": [
             {
                 "value": "glm-5",


### PR DESCRIPTION
Follow-up to #40 (which added the DSE-nimbus picker entry). Based on recent tests, set the boot default (`llm_model`) to the Nimbus/DSE-hosted `qwen` model. Part of a fleet-wide default switch coordinated in geo-agent-ops.