### PR TITLE
config: serve anthropic/claude-sonnet-5 via OpenRouter path

### DIFF
--- a/k8s/configmap.yaml
+++ b/k8s/configmap.yaml
@@ -58,8 +58,8 @@ data:
                 "api_key": "unused"
             },
             {
-                "value": "claude-sonnet-4-6",
-                "label": "Claude Sonnet 4.6",
+                "value": "anthropic/claude-sonnet-5",
+                "label": "Claude Sonnet 5",
                 "endpoint": "/api/llm",
                 "api_key": "unused"
             }


### PR DESCRIPTION
Standardize the Claude option on the OpenRouter path serving `anthropic/claude-sonnet-5` (matching ca-30x30, the reference case).

- `claude-sonnet-4-6` (bare proxy id) -> `anthropic/claude-sonnet-5` (OpenRouter, provider-prefixed)
- `anthropic/claude-sonnet-4` -> `anthropic/claude-sonnet-5` (already OpenRouter; model version bump)
- picker label -> "Claude Sonnet 5"

Config source only; no deploy (rolls out with the upcoming geo-agent version bump).