### PR TITLE
bump geo-agent -> @v3.20.0

### DIFF
--- a/index.html
+++ b/index.html
@@ -60,9 +60,9 @@
         crossorigin="anonymous"></script>
 
     <!-- Core styles from CDN -->
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/boettiger-lab/geo-agent@v3.17.1/app/style.css">
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/boettiger-lab/geo-agent@v3.17.1/app/chat.css">
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/boettiger-lab/geo-agent@v3.17.1/app/sidebar.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/boettiger-lab/geo-agent@v3.20.0/app/style.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/boettiger-lab/geo-agent@v3.20.0/app/chat.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/boettiger-lab/geo-agent@v3.20.0/app/sidebar.css">
 </head>
 
 <body>
@@ -75,7 +75,7 @@
     <!-- Chat scaffold is built dynamically by the sidebar layout manager (v3.2.0+). -->
 
     <!-- Boot from CDN -->
-    <script type="module" src="https://cdn.jsdelivr.net/gh/boettiger-lab/geo-agent@v3.17.1/app/main.js"></script>
+    <script type="module" src="https://cdn.jsdelivr.net/gh/boettiger-lab/geo-agent@v3.20.0/app/main.js"></script>
 </body>
 
 </html>


### PR DESCRIPTION
Fleet pin bump to geo-agent `@v3.20.0`. CDN pre-checked 200 for app/main.js, chat.css, sidebar.css, style.css.