### PR TITLE
k8s: cap nginx worker_processes to 2 (fixes OOM on large NRP nodes, geo-agent-ops#49)

### DIFF
--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -73,6 +73,12 @@ spec:
           # are preserved.
           envsubst '$${PROXY_KEY}' < /nginx-template/nginx.conf.template \
             > /etc/nginx/conf.d/default.conf
+          # Pin worker_processes low: the base image defaults to
+          # 'auto' (one worker per CPU), which spawns hundreds of
+          # workers on large NRP nodes and OOM-kills the 256Mi limit.
+          # -g can't override it (duplicate directive), so patch the
+          # main config in place before launching.
+          sed -i 's/^worker_processes.*/worker_processes 2;/' /etc/nginx/nginx.conf
           nginx -g 'daemon off;'
         resources:
           requests:


### PR DESCRIPTION
Caps nginx `worker_processes` to 2 in the nginx container command, matching the fix already baked into `geo-agent-template` and `barred-owl`.

**Why:** the stock `nginx:alpine` main config uses `worker_processes auto` (one worker per CPU). On large NRP nodes (100+ cores) that spawns 300+ workers, blows past the 256Mi memory limit, and OOM-crash-loops the new pod — while the stale pod keeps serving old code. A `rollout restart` reports success but the new pin never goes live (node-luck dependent).

The `-g 'worker_processes 2;'` override doesn't work (nginx rejects it as a duplicate directive), so we patch the main config in place before launch.

No behavior change beyond the worker cap. Tracking: boettiger-lab/geo-agent-ops#49