### PR TITLE
feat(map): enable draw tool for polygon spatial queries

### DIFF
--- a/docs.html
+++ b/docs.html
@@ -231,6 +231,10 @@ p.lede { font-size: 1.05rem; color: var(--ink-soft); }
         <li>PMTiles layers don't use a fixed legend. <strong>Hover</strong> over any feature for a tooltip with that feature's live attributes — values, names, categories — direct from the source data.</li>
         <li>Every tool call the assistant runs is logged in the per-turn timeline — with timings — so you can see what it queried, with what arguments, what came back, and how long each step took.</li>
     </ul>
+
+    <div class="callout">
+        <strong>✏️ Draw an area to ask about it.</strong> Use the <strong>draw tool</strong> on the map to sketch a polygon — a proposed acquisition, a watershed, a neighborhood, anywhere in California — then ask the assistant about it: <em>"How much protected acreage falls inside the area I drew?"</em>, <em>"Which conservation programs have funded projects in this polygon?"</em>, <em>"What share of this area overlaps high-pollution communities in CalEnviroScreen?"</em> Your drawn shape becomes a live spatial filter for any query.
+    </div>
 </section>
 
 <section>

--- a/layers-input.json
+++ b/layers-input.json
@@ -2,6 +2,7 @@
     "catalog": "https://s3-west.nrp-nautilus.io/public-data/stac/catalog.json",
     "titiler_url": "https://titiler.nrp-nautilus.io",
     "mcp_url": "https://duckdb-mcp.nrp-nautilus.io/mcp",
+    "draw_enabled": true,
     "auto_approve": true,
     "sidebar": {
         "enabled": true,


### PR DESCRIPTION
Enables the map **draw tool** (`"draw_enabled": true` in `layers-input.json`), matching the working bosl-high-seas app. Users can sketch a polygon and use it as a live spatial filter for queries.

Also documents the feature in `docs.html` with CA conservation examples (protected acreage, funding programs, CalEnviroScreen overlap inside a drawn area).

## Rollout
After merge, restart the `tpl-ca` deployment so its init-container re-clones `main`.