### PR TITLE
Model picker: OpenRouter GLM-5.2 replaces NRP GLM; add DeepSeek V4 Flash

### DIFF
--- a/k8s/configmap.yaml
+++ b/k8s/configmap.yaml
@@ -22,8 +22,8 @@ data:
                 "api_key": "unused"
             },
             {
-                "value": "glm-5",
-                "label": "NRP GLM-5",
+                "value": "deepseek/deepseek-v4-flash",
+                "label": "DeepSeek V4 Flash (OpenRouter)",
                 "endpoint": "/api/llm",
                 "api_key": "unused"
             },


### PR DESCRIPTION
Adjusts the `llm_models` picker in `k8s/configmap.yaml`:

- **NRP GLM entry → OpenRouter GLM-5.2.** NRP's own GLM is served under id `glm-5` (which is actually GLM-5.2), and NRP no longer serves `glm-4.7` (that "NRP GLM-4.7" entry was dead). The NRP GLM entry is replaced by OpenRouter `z-ai/glm-5.2` ("GLM-5.2 (OpenRouter)"); where OpenRouter glm-5.2 was already listed, the duplicate NRP `glm-5` entry is simply dropped.
- **New option: `deepseek/deepseek-v4-flash`** ("DeepSeek V4 Flash (OpenRouter)"). Routing enabled by open-llm-proxy#90 (adds the `deepseek/` family), already merged + deployed + verified.

Default model unchanged.